### PR TITLE
Do not require rubygems in library code.

### DIFF
--- a/lib/robotex.rb
+++ b/lib/robotex.rb
@@ -1,7 +1,6 @@
 # Author (2012): Chris Kite
 # Original Author (2008-2011): Kyle Maxwell
 
-require 'rubygems'
 require 'open-uri'
 require 'uri'
 require 'timeout'


### PR DESCRIPTION
It's a good practice to not require rubygems in library code.

See http://guides.rubygems.org/patterns/#declaring-dependencies and
http://tomayko.com/writings/require-rubygems-antipattern for more info.
